### PR TITLE
Fix request handler

### DIFF
--- a/schoology-oauth/src/main/java/net/rvanasa/schoology/impl/OAuthSchoologyRequestHandler.java
+++ b/schoology-oauth/src/main/java/net/rvanasa/schoology/impl/OAuthSchoologyRequestHandler.java
@@ -83,6 +83,7 @@ public class OAuthSchoologyRequestHandler implements SchoologyRequestHandler
 		OAuthRequest request = new OAuthRequest(verb, getResourceLocator().getRequestUrl(resource));
 		getOAuthService().signRequest(getAccessToken() != null ? getAccessToken() : Token.empty(), request);
 		request.addHeader("Accept", getContentType().getID());
+		request.addHeader("Content-Type", getContentType().getID());
 		return request;
 	}
 	

--- a/schoology-oauth/src/main/java/net/rvanasa/schoology/impl/SchoologyResponseStatusEnum.java
+++ b/schoology-oauth/src/main/java/net/rvanasa/schoology/impl/SchoologyResponseStatusEnum.java
@@ -4,7 +4,10 @@ import net.rvanasa.schoology.SchoologyResponseStatus;
 
 public enum SchoologyResponseStatusEnum implements SchoologyResponseStatus
 {
-	SUCCESS(200, "OK"),
+	SUCCESS_OK(200, "OK"),
+	SUCCESS_CREATED(201, "Create"),
+	SUCCESS_NO_CONTENT(204, "No content"),
+	
 	PERMISSION(403, "Insufficient permission level"),
 	NOT_FOUND(404, "Resource not found");
 	
@@ -32,7 +35,7 @@ public enum SchoologyResponseStatusEnum implements SchoologyResponseStatus
 	@Override
 	public boolean isSuccess()
 	{
-		return this == SUCCESS;
+		return this.name().startsWith("SUCCESS");
 	}
 	
 	public static SchoologyResponseStatus getStatus(int code)


### PR DESCRIPTION
Fixes problem where making a JSON post or put fails. Schoology returns a 415 if the content-type is not specified.

Also fixes SchoologyResponse#requireSuccess when making a request regarding a post or put.